### PR TITLE
ci: scope cpp-linter token to read-only

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "npsr/*"
 
+permissions:
+  contents: read
+
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the cpp-linter workflow. The workflow checks out source and runs a C++ linter on changed files. Read access to repository contents is sufficient for the linter to inspect PR files.